### PR TITLE
[Feat] (page) ProjectExperiencePage, OtherExperiencePage, SkillsPage, FinalSummaryPage 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,7 @@ const router = createBrowserRouter([
                 element: <CareerNotePage />,
             },
             {
-                path: 'career/save',
+                path: 'career/success',
                 element: <CareerSavePage />,
             },
             {

--- a/src/components/common/TextTemplate/TextTemplate.jsx
+++ b/src/components/common/TextTemplate/TextTemplate.jsx
@@ -3,7 +3,7 @@ import { useTemplateData } from '../../../hooks/useTemplateData';
 import { textTemplateData } from '../../../data/textTemplateData';
 import UnderlineButton from '../Button/UnderlineButton/UnderlineButton';
 
-const TextTemplate = ({ data: externalData, onDataChange }) => {
+const TextTemplate = ({ data: externalData, onDataChange, TableCellHeader }) => {
     const initialData = textTemplateData;
     const { handleInputChange, data, clearAll } = useTemplateData(externalData || initialData, onDataChange);
 
@@ -22,12 +22,12 @@ const TextTemplate = ({ data: externalData, onDataChange }) => {
                     <S.TemplateTable>
                         {section.items.map((item, itemIndex) => (
                             <S.TableRow key={itemIndex}>
-                                <S.TableCellHeader
+                                <TableCellHeader
                                     isFirstRow={itemIndex === 0}
                                     isLastRow={itemIndex === section.items.length - 1}
                                 >
                                     {item.label}
-                                </S.TableCellHeader>
+                                </TableCellHeader>
                                 <S.TableCellData
                                     isFirstRow={itemIndex === 0}
                                     isLastRow={itemIndex === section.items.length - 1}

--- a/src/components/common/TextTemplate/TextTemplate.jsx
+++ b/src/components/common/TextTemplate/TextTemplate.jsx
@@ -3,9 +3,9 @@ import { useTemplateData } from '../../../hooks/useTemplateData';
 import { textTemplateData } from '../../../data/textTemplateData';
 import UnderlineButton from '../Button/UnderlineButton/UnderlineButton';
 
-const TextTemplate = ({ onDataChange }) => {
+const TextTemplate = ({ data: externalData, onDataChange }) => {
     const initialData = textTemplateData;
-    const { handleInputChange, data, clearAll } = useTemplateData(initialData, onDataChange);
+    const { handleInputChange, data, clearAll } = useTemplateData(externalData || initialData, onDataChange);
 
     const autoResize = (textarea) => {
         if (textarea) {
@@ -43,7 +43,7 @@ const TextTemplate = ({ onDataChange }) => {
                         ))}
                     </S.TemplateTable>
                     <S.ButtonWrapper>
-                        <UnderlineButton onClick={clearAll}>전체 내용 삭제하기</UnderlineButton>
+                        <UnderlineButton onClick={() => clearAll(sectionIndex)}>전체 내용 삭제하기</UnderlineButton>
                     </S.ButtonWrapper>
                 </S.TemplateWrapper>
             ))}

--- a/src/components/common/UserTemplate/Template.jsx
+++ b/src/components/common/UserTemplate/Template.jsx
@@ -104,7 +104,7 @@ const Template = ({ jobType = 'frontend', pageType = 'internExperience', data: e
                         ))}
                     </S.TemplateTable>
                     <S.ButtonWrapper>
-                        <UnderlineButton onClick={clearAll}>전체 내용 삭제하기</UnderlineButton>
+                        <UnderlineButton onClick={() => clearAll(sectionIndex)}>전체 내용 삭제하기</UnderlineButton>
                     </S.ButtonWrapper>
                 </S.TemplateWrapper>
             ))}

--- a/src/components/common/UserTemplate/Template.jsx
+++ b/src/components/common/UserTemplate/Template.jsx
@@ -6,7 +6,7 @@ import { jobTemplateData } from '../../../data/jobTemplateData';
 import * as S from './styled/styled';
 import UnderlineButton from '../Button/UnderlineButton/UnderlineButton';
 
-const Template = ({ jobType = 'frontend', pageType = 'internExperience', onDataChange }) => {
+const Template = ({ jobType = 'frontend', pageType = 'internExperience', data: externalData, onDataChange }) => {
     const initialData = jobTemplateData[pageType]?.[jobType] || [];
     const {
         tooltipVisible,
@@ -16,7 +16,7 @@ const Template = ({ jobType = 'frontend', pageType = 'internExperience', onDataC
         handleDateChange,
         generateTooltipText,
         clearAll,
-    } = useTemplateData(initialData, onDataChange);
+    } = useTemplateData(externalData || initialData, onDataChange);
 
     const autoResize = (textarea) => {
         if (textarea) {

--- a/src/data/jobTemplateData.js
+++ b/src/data/jobTemplateData.js
@@ -276,4 +276,163 @@ export const jobTemplateData = {
             },
         ],
     },
+
+    otherExperience: {
+        frontend: [
+            {
+                title: '',
+                items: [
+                    {
+                        label: '활동명',
+                        content: '',
+                        placeholder: '활동명을 입력해주세요',
+                        type: 'text',
+                        required: true,
+                    },
+                    {
+                        label: '기간',
+                        content: '',
+                        placeholder: '기간을 입력해주세요',
+                        type: 'date',
+                        startDate: null,
+                        endDate: null,
+                    },
+                    {
+                        label: '주요 성과 및 역할',
+                        content: '',
+                        placeholder: '주요 성과 및 역할을 입력해주세요',
+                        type: 'text',
+                    },
+                    {
+                        label: '나에게 의미 있었던 점',
+                        content: '',
+                        placeholder: '나에게 의미 있었던 점을 입력해주세요',
+                        type: 'text',
+                    },
+                    {
+                        label: '내가 성장한 부분',
+                        content: '',
+                        placeholder: '내가 성장한 부분을 입력해주세요',
+                        type: 'text',
+                    },
+                ],
+            },
+            {
+                title: '',
+                items: [
+                    {
+                        label: '활동명',
+                        content: '',
+                        placeholder: '활동명을 입력해주세요',
+                        type: 'text',
+                        required: true,
+                    },
+                    {
+                        label: '기간',
+                        content: '',
+                        placeholder: '기간을 입력해주세요',
+                        type: 'date',
+                        startDate: null,
+                        endDate: null,
+                    },
+                    {
+                        label: '주요 성과 및 역할',
+                        content: '',
+                        placeholder: '주요 성과 및 역할을 입력해주세요',
+                        type: 'text',
+                    },
+                    {
+                        label: '나에게 의미 있었던 점',
+                        content: '',
+                        placeholder: '나에게 의미 있었던 점을 입력해주세요',
+                        type: 'text',
+                    },
+                    {
+                        label: '내가 성장한 부분',
+                        content: '',
+                        placeholder: '내가 성장한 부분을 입력해주세요',
+                        type: 'text',
+                    },
+                ],
+            },
+        ],
+        backend: [
+            {
+                title: '',
+                items: [
+                    {
+                        label: '활동명',
+                        content: '',
+                        placeholder: '활동명을 입력해주세요',
+                        type: 'text',
+                        required: true,
+                    },
+                    {
+                        label: '기간',
+                        content: '',
+                        placeholder: '기간을 입력해주세요',
+                        type: 'date',
+                        startDate: null,
+                        endDate: null,
+                    },
+                    {
+                        label: '주요 성과 및 역할',
+                        content: '',
+                        placeholder: '주요 성과 및 역할을 입력해주세요',
+                        type: 'text',
+                    },
+                    {
+                        label: '나에게 의미 있었던 점',
+                        content: '',
+                        placeholder: '나에게 의미 있었던 점을 입력해주세요',
+                        type: 'text',
+                    },
+                    {
+                        label: '내가 성장한 부분',
+                        content: '',
+                        placeholder: '내가 성장한 부분을 입력해주세요',
+                        type: 'text',
+                    },
+                ],
+            },
+            {
+                title: '',
+                items: [
+                    {
+                        label: '활동명',
+                        content: '',
+                        placeholder: '활동명을 입력해주세요',
+                        type: 'text',
+                        required: true,
+                    },
+                    {
+                        label: '기간',
+                        content: '',
+                        placeholder: '기간을 입력해주세요',
+                        type: 'date',
+                        startDate: null,
+                        endDate: null,
+                    },
+                    {
+                        label: '주요 성과 및 역할',
+                        content: '',
+                        placeholder: '주요 성과 및 역할을 입력해주세요',
+                        type: 'text',
+                    },
+                    {
+                        label: '나에게 의미 있었던 점',
+                        content: '',
+                        placeholder: '나에게 의미 있었던 점을 입력해주세요',
+                        type: 'text',
+                    },
+                    {
+                        label: '내가 성장한 부분',
+                        content: '',
+                        placeholder: '내가 성장한 부분을 입력해주세요',
+                        type: 'text',
+                    },
+                ],
+            },
+        ],
+    },
 };

--- a/src/data/jobTemplateData.js
+++ b/src/data/jobTemplateData.js
@@ -60,7 +60,35 @@ export const jobTemplateData = {
         ],
         backend: [
             {
-                title: '1. 인턴 경험',
+                title: '',
+                items: [
+                    {
+                        label: '직무명',
+                        content: '',
+                        placeholder: '직무명을 입력해주세요',
+                        type: 'text',
+                        required: true,
+                    },
+                    {
+                        label: '근무기간',
+                        content: '',
+                        placeholder: '근무기간을 입력해주세요',
+                        type: 'date',
+                        startDate: null,
+                        endDate: null,
+                    },
+                    { label: '사용 기술', content: '', placeholder: '사용 기술을 입력해주세요', type: 'text' },
+                    { label: '해결한 문제', content: '', placeholder: '해결한 문제를 입력해주세요', type: 'text' },
+                    {
+                        label: '느낀점 / 배운점',
+                        content: '',
+                        placeholder: '느낀점/배운점을 입력해주세요',
+                        type: 'text',
+                    },
+                ],
+            },
+            {
+                title: '',
                 items: [
                     {
                         label: '직무명',
@@ -93,7 +121,7 @@ export const jobTemplateData = {
     projectExperience: {
         frontend: [
             {
-                title: '2. 프로젝트 경험',
+                title: '',
                 items: [
                     {
                         label: '프로젝트명',
@@ -111,9 +139,47 @@ export const jobTemplateData = {
                         endDate: null,
                     },
                     {
-                        label: '개발한 프론트 파트 / 맡은 역할',
+                        label: '주요 성과 및 역할',
                         content: '',
-                        placeholder: '개발한 파트 / 맡은 역할을 입력해주세요',
+                        placeholder: '주요 성과 및 역할을 입력해주세요',
+                        type: 'text',
+                    },
+                    {
+                        label: '나에게 의미 있었던 점',
+                        content: '',
+                        placeholder: '나에게 의미 있었던 점을 입력해주세요',
+                        type: 'text',
+                    },
+                    {
+                        label: '내가 성장한 부분',
+                        content: '',
+                        placeholder: '내가 성장한 부분을 입력해주세요',
+                        type: 'text',
+                    },
+                ],
+            },
+            {
+                title: '',
+                items: [
+                    {
+                        label: '프로젝트명',
+                        content: '',
+                        placeholder: '프로젝트명을 입력해주세요',
+                        type: 'text',
+                        required: true,
+                    },
+                    {
+                        label: '기간',
+                        content: '',
+                        placeholder: '기간을 입력해주세요',
+                        type: 'date',
+                        startDate: null,
+                        endDate: null,
+                    },
+                    {
+                        label: '주요 성과 및 역할',
+                        content: '',
+                        placeholder: '주요 성과 및 역할을 입력해주세요',
                         type: 'text',
                     },
                     {
@@ -133,7 +199,7 @@ export const jobTemplateData = {
         ],
         backend: [
             {
-                title: '2. 프로젝트 경험',
+                title: '',
                 items: [
                     {
                         label: '프로젝트명',
@@ -151,9 +217,47 @@ export const jobTemplateData = {
                         endDate: null,
                     },
                     {
-                        label: '개발한 백엔드 파트 / 맡은 역할',
+                        label: '주요 성과 및 역할',
                         content: '',
-                        placeholder: '개발한 파트 / 맡은 역할을 입력해주세요',
+                        placeholder: '주요 성과 및 역할을 입력해주세요',
+                        type: 'text',
+                    },
+                    {
+                        label: '나에게 의미 있었던 점',
+                        content: '',
+                        placeholder: '나에게 의미 있었던 점을 입력해주세요',
+                        type: 'text',
+                    },
+                    {
+                        label: '내가 성장한 부분',
+                        content: '',
+                        placeholder: '내가 성장한 부분을 입력해주세요',
+                        type: 'text',
+                    },
+                ],
+            },
+            {
+                title: '',
+                items: [
+                    {
+                        label: '프로젝트명',
+                        content: '',
+                        placeholder: '프로젝트명을 입력해주세요',
+                        type: 'text',
+                        required: true,
+                    },
+                    {
+                        label: '기간',
+                        content: '',
+                        placeholder: '기간을 입력해주세요',
+                        type: 'date',
+                        startDate: null,
+                        endDate: null,
+                    },
+                    {
+                        label: '주요 성과 및 역할',
+                        content: '',
+                        placeholder: '주요 성과 및 역할을 입력해주세요',
                         type: 'text',
                     },
                     {

--- a/src/data/textTemplateData.js
+++ b/src/data/textTemplateData.js
@@ -1,29 +1,177 @@
-export const textTemplateData = [
-    {
-        title: '5. 최종 정리',
-        items: [
+export const textTemplateData = {
+    skills: {
+        frontend: [
             {
-                label: '위에 기술한 경험들을 통해 내가 성장한 부분은 무엇인가요?',
-                content: '',
-                placeholder: '내용을 입력해주세요',
+                title: '',
+                items: [
+                    {
+                        label: '보유 기술',
+                        content: '',
+                        placeholder: '보유 기술을 입력해주세요',
 
-                required: true,
+                        required: true,
+                    },
+                    {
+                        label: '나의 기술 강점',
+                        content: '',
+                        placeholder: '자신의 기술 강점을 입력해주세요',
+                    },
+                    {
+                        label: '개선하고 싶은 부분',
+                        content: '',
+                        placeholder: '개선하고 싶은 부분을 입력해주세요',
+                    },
+                    {
+                        label: '이 직무에서 나의 성향',
+                        content: '',
+                        placeholder: '이 직무에서 자신의 성향을 입력해주세요',
+                    },
+                ],
             },
             {
-                label: '다양한 경험을 통해 발견한 나의 성향이나 강점은 무엇인가요?',
-                content: '',
-                placeholder: '내용을 입력해주세요',
+                title: '',
+                items: [
+                    {
+                        label: '보유 기술',
+                        content: '',
+                        placeholder: '보유 기술을 입력해주세요',
+
+                        required: true,
+                    },
+                    {
+                        label: '나의 기술 강점',
+                        content: '',
+                        placeholder: '자신의 기술 강점을 입력해주세요',
+                    },
+                    {
+                        label: '개선하고 싶은 부분',
+                        content: '',
+                        placeholder: '개선하고 싶은 부분을 입력해주세요',
+                    },
+                    {
+                        label: '이 직무에서 나의 성향',
+                        content: '',
+                        placeholder: '이 직무에서 자신의 성향을 입력해주세요',
+                    },
+                ],
+            },
+        ],
+        backend: [
+            {
+                title: '',
+                items: [
+                    {
+                        label: '보유 기술',
+                        content: '',
+                        placeholder: '보유 기술을 입력해주세요',
+
+                        required: true,
+                    },
+                    {
+                        label: '나의 기술 강점',
+                        content: '',
+                        placeholder: '자신의 기술 강점을 입력해주세요',
+                    },
+                    {
+                        label: '개선하고 싶은 부분',
+                        content: '',
+                        placeholder: '개선하고 싶은 부분을 입력해주세요',
+                    },
+                    {
+                        label: '이 직무에서 나의 성향',
+                        content: '',
+                        placeholder: '이 직무에서 자신의 성향을 입력해주세요',
+                    },
+                ],
             },
             {
-                label: '다양한 경험을 통해 발견한 나의 단점은 무엇이고, 이를 어떻게 보완할 계획인가요?',
-                content: '',
-                placeholder: '내용을 입력해주세요',
-            },
-            {
-                label: '앞으로 어떤 모습의 웹 개발자로 성장하고 싶나요?',
-                content: '',
-                placeholder: '내용을 입력해주세요',
+                title: '',
+                items: [
+                    {
+                        label: '보유 기술',
+                        content: '',
+                        placeholder: '보유 기술을 입력해주세요',
+
+                        required: true,
+                    },
+                    {
+                        label: '나의 기술 강점',
+                        content: '',
+                        placeholder: '자신의 기술 강점을 입력해주세요',
+                    },
+                    {
+                        label: '개선하고 싶은 부분',
+                        content: '',
+                        placeholder: '개선하고 싶은 부분을 입력해주세요',
+                    },
+                    {
+                        label: '이 직무에서 나의 성향',
+                        content: '',
+                        placeholder: '이 직무에서 자신의 성향을 입력해주세요',
+                    },
+                ],
             },
         ],
     },
-];
+
+    summary: {
+        frontend: [
+            {
+                title: '5. 최종 정리',
+                items: [
+                    {
+                        label: '위에 기술한 경험들을 통해 내가 성장한 부분은 무엇인가요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+
+                        required: true,
+                    },
+                    {
+                        label: '다양한 경험을 통해 발견한 나의 성향이나 강점은 무엇인가요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+                    },
+                    {
+                        label: '다양한 경험을 통해 발견한 나의 단점은 무엇이고, 이를 어떻게 보완할 계획인가요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+                    },
+                    {
+                        label: '앞으로 어떤 모습의 웹 개발자로 성장하고 싶나요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+                    },
+                ],
+            },
+        ],
+        backend: [
+            {
+                title: '5. 최종 정리',
+                items: [
+                    {
+                        label: '위에 기술한 경험들을 통해 내가 성장한 부분은 무엇인가요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+
+                        required: true,
+                    },
+                    {
+                        label: '다양한 경험을 통해 발견한 나의 성향이나 강점은 무엇인가요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+                    },
+                    {
+                        label: '다양한 경험을 통해 발견한 나의 단점은 무엇이고, 이를 어떻게 보완할 계획인가요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+                    },
+                    {
+                        label: '앞으로 어떤 모습의 웹 개발자로 성장하고 싶나요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+                    },
+                ],
+            },
+        ],
+    },
+};

--- a/src/data/textTemplateData.js
+++ b/src/data/textTemplateData.js
@@ -117,7 +117,34 @@ export const textTemplateData = {
     summary: {
         frontend: [
             {
-                title: '5. 최종 정리',
+                title: '',
+                items: [
+                    {
+                        label: '위에 기술한 경험들을 통해 내가 성장한 부분은 무엇인가요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+
+                        required: true,
+                    },
+                    {
+                        label: '다양한 경험을 통해 발견한 나의 성향이나 강점은 무엇인가요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+                    },
+                    {
+                        label: '다양한 경험을 통해 발견한 나의 단점은 무엇이고, 이를 어떻게 보완할 계획인가요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+                    },
+                    {
+                        label: '앞으로 어떤 모습의 웹 개발자로 성장하고 싶나요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+                    },
+                ],
+            },
+            {
+                title: '',
                 items: [
                     {
                         label: '위에 기술한 경험들을 통해 내가 성장한 부분은 무엇인가요?',
@@ -146,7 +173,34 @@ export const textTemplateData = {
         ],
         backend: [
             {
-                title: '5. 최종 정리',
+                title: '',
+                items: [
+                    {
+                        label: '위에 기술한 경험들을 통해 내가 성장한 부분은 무엇인가요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+
+                        required: true,
+                    },
+                    {
+                        label: '다양한 경험을 통해 발견한 나의 성향이나 강점은 무엇인가요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+                    },
+                    {
+                        label: '다양한 경험을 통해 발견한 나의 단점은 무엇이고, 이를 어떻게 보완할 계획인가요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+                    },
+                    {
+                        label: '앞으로 어떤 모습의 웹 개발자로 성장하고 싶나요?',
+                        content: '',
+                        placeholder: '내용을 입력해주세요',
+                    },
+                ],
+            },
+            {
+                title: '',
                 items: [
                     {
                         label: '위에 기술한 경험들을 통해 내가 성장한 부분은 무엇인가요?',

--- a/src/hooks/useTemplateData.js
+++ b/src/hooks/useTemplateData.js
@@ -45,6 +45,7 @@ export const useTemplateData = (initialData, onDataChange) => {
             })),
         }));
         setData(clearedData);
+        onDataChange(clearedData);
     };
 
     return {

--- a/src/hooks/useTemplateData.js
+++ b/src/hooks/useTemplateData.js
@@ -34,18 +34,24 @@ export const useTemplateData = (initialData, onDataChange) => {
         return `${labels}은 꼭 입력해주세요!`;
     };
 
-    const clearAll = () => {
-        const clearedData = data.map((section) => ({
-            ...section,
-            items: section.items.map((item) => ({
-                ...item,
-                content: '',
-                startDate: null,
-                endDate: null,
-            })),
-        }));
-        setData(clearedData);
-        onDataChange(clearedData);
+    const clearAll = (sectionIndex) => {
+        const updatedData = data.map((section, index) => {
+            if (index === sectionIndex) {
+                return {
+                    ...section,
+                    items: section.items.map((item) => ({
+                        ...item,
+                        content: '',
+                        startDate: null,
+                        endDate: null,
+                    })),
+                };
+            }
+            return section;
+        });
+
+        setData(updatedData);
+        onDataChange(updatedData);
     };
 
     return {

--- a/src/pages/Career/CareerMainPage/CareerMainPage.jsx
+++ b/src/pages/Career/CareerMainPage/CareerMainPage.jsx
@@ -1,16 +1,21 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import searchIcon from '../../../assets/MainPage/search.svg';
 import InfoContainer from '../../../components/common/InfoContainer/InfoContainer';
 import LoadingPopup from '../../../components/common/Popups/LoadingPopup/LoadingPopup';
 import * as S from './styled/styled';
 
 const CareerMainPage = () => {
+    const navigate = useNavigate();
     const userName = '김단아';
     const job = '프론트엔드 개발자';
     const [isPopUpVisible, setIsPopUpVisible] = useState(false);
 
     const handleButtonClick = () => {
         setIsPopUpVisible(true);
+        setTimeout(() => {
+            navigate('/career/note');
+        }, 1500);
     };
 
     const handlePopUpCancel = () => {

--- a/src/pages/Career/CareerPage/CareerNotePage.jsx
+++ b/src/pages/Career/CareerPage/CareerNotePage.jsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import InternExperiencePage from '../InternExperiencePage/InternExperiencePage';
 import ProjectExperiencePage from '../ProjectExperiencePage/ProjectExperiencePage';
 import OtherExperiencePage from '../OtherExperiencePage/OtherExperiencePage';
+import SkillsPage from '../SkillsPage/SkillsPage';
 
 const CareerNotePage = () => {
     const [activeScreen, setActiveScreen] = useState(0);
@@ -17,7 +18,7 @@ const CareerNotePage = () => {
             case 2:
                 return <OtherExperiencePage setActiveScreen={setActiveScreen} />;
             case 3:
-                return <HomePage />;
+                return <SkillsPage setActiveScreen={setActiveScreen} />;
             case 4:
                 return <HomePage />;
             default:

--- a/src/pages/Career/CareerPage/CareerNotePage.jsx
+++ b/src/pages/Career/CareerPage/CareerNotePage.jsx
@@ -3,6 +3,7 @@ import HomePage from '../../HomePage';
 import { useState } from 'react';
 import InternExperiencePage from '../InternExperiencePage/InternExperiencePage';
 import ProjectExperiencePage from '../ProjectExperiencePage/ProjectExperiencePage';
+import OtherExperiencePage from '../OtherExperiencePage/OtherExperiencePage';
 
 const CareerNotePage = () => {
     const [activeScreen, setActiveScreen] = useState(0);
@@ -14,7 +15,7 @@ const CareerNotePage = () => {
             case 1:
                 return <ProjectExperiencePage setActiveScreen={setActiveScreen} />;
             case 2:
-                return <HomePage />;
+                return <OtherExperiencePage setActiveScreen={setActiveScreen} />;
             case 3:
                 return <HomePage />;
             case 4:

--- a/src/pages/Career/CareerPage/CareerNotePage.jsx
+++ b/src/pages/Career/CareerPage/CareerNotePage.jsx
@@ -1,10 +1,12 @@
 import * as S from './styled/styled';
-import HomePage from '../../HomePage';
 import { useState } from 'react';
 import InternExperiencePage from '../InternExperiencePage/InternExperiencePage';
 import ProjectExperiencePage from '../ProjectExperiencePage/ProjectExperiencePage';
 import OtherExperiencePage from '../OtherExperiencePage/OtherExperiencePage';
 import SkillsPage from '../SkillsPage/SkillsPage';
+import FinalSummaryPage from '../FinalSummaryPage/FinalSummaryPage';
+import CareerSavePage from '../CareerSavePage/CareerSavePage';
+import CareerMainPage from '../CareerMainPage/CareerMainPage';
 
 const CareerNotePage = () => {
     const [activeScreen, setActiveScreen] = useState(0);
@@ -20,9 +22,11 @@ const CareerNotePage = () => {
             case 3:
                 return <SkillsPage setActiveScreen={setActiveScreen} />;
             case 4:
-                return <HomePage />;
+                return <FinalSummaryPage setActiveScreen={setActiveScreen} />;
+            case 5:
+                return <CareerSavePage setActiveScreen={setActiveScreen} />;
             default:
-                return <HomePage />;
+                return <CareerMainPage />;
         }
     };
 

--- a/src/pages/Career/CareerPage/CareerNotePage.jsx
+++ b/src/pages/Career/CareerPage/CareerNotePage.jsx
@@ -1,5 +1,5 @@
 import * as S from './styled/styled';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import InternExperiencePage from '../InternExperiencePage/InternExperiencePage';
 import ProjectExperiencePage from '../ProjectExperiencePage/ProjectExperiencePage';
 import OtherExperiencePage from '../OtherExperiencePage/OtherExperiencePage';
@@ -9,6 +9,9 @@ import CareerMainPage from '../CareerMainPage/CareerMainPage';
 
 const CareerNotePage = () => {
     const [activeScreen, setActiveScreen] = useState(0);
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [activeScreen]);
 
     const renderScreen = () => {
         switch (activeScreen) {

--- a/src/pages/Career/CareerPage/CareerNotePage.jsx
+++ b/src/pages/Career/CareerPage/CareerNotePage.jsx
@@ -5,7 +5,6 @@ import ProjectExperiencePage from '../ProjectExperiencePage/ProjectExperiencePag
 import OtherExperiencePage from '../OtherExperiencePage/OtherExperiencePage';
 import SkillsPage from '../SkillsPage/SkillsPage';
 import FinalSummaryPage from '../FinalSummaryPage/FinalSummaryPage';
-import CareerSavePage from '../CareerSavePage/CareerSavePage';
 import CareerMainPage from '../CareerMainPage/CareerMainPage';
 
 const CareerNotePage = () => {
@@ -23,8 +22,6 @@ const CareerNotePage = () => {
                 return <SkillsPage setActiveScreen={setActiveScreen} />;
             case 4:
                 return <FinalSummaryPage setActiveScreen={setActiveScreen} />;
-            case 5:
-                return <CareerSavePage setActiveScreen={setActiveScreen} />;
             default:
                 return <CareerMainPage />;
         }

--- a/src/pages/Career/CareerPage/CareerNotePage.jsx
+++ b/src/pages/Career/CareerPage/CareerNotePage.jsx
@@ -1,7 +1,8 @@
 import * as S from './styled/styled';
 import HomePage from '../../HomePage';
-import InternExperiencePage from '../InternExperiencePage/InternExperiencePage';
 import { useState } from 'react';
+import InternExperiencePage from '../InternExperiencePage/InternExperiencePage';
+import ProjectExperiencePage from '../ProjectExperiencePage/ProjectExperiencePage';
 
 const CareerNotePage = () => {
     const [activeScreen, setActiveScreen] = useState(0);
@@ -11,7 +12,7 @@ const CareerNotePage = () => {
             case 0:
                 return <InternExperiencePage setActiveScreen={setActiveScreen} />;
             case 1:
-                return <HomePage />;
+                return <ProjectExperiencePage setActiveScreen={setActiveScreen} />;
             case 2:
                 return <HomePage />;
             case 3:

--- a/src/pages/Career/FinalSummaryPage/FinalSummaryPage.jsx
+++ b/src/pages/Career/FinalSummaryPage/FinalSummaryPage.jsx
@@ -7,7 +7,7 @@ import useProgressBar from '../../../hooks/useProgressBar';
 import { TableCellHeader } from '../../../components/common/TextTemplate/styled/styled';
 
 const FinalSummaryPage = ({ setActiveScreen }) => {
-    const { data, setData, canSave, handleSave } = useFinalSummary();
+    const { data, setData, handleSave } = useFinalSummary();
     const { progression, prevSummaryProgress, nextSummaryProgress } = useProgressBar(5);
 
     const handlePrevClick = () => {
@@ -39,7 +39,7 @@ const FinalSummaryPage = ({ setActiveScreen }) => {
             </S.TemplateWrapper>
 
             <S.ButtonWrapper>
-                <SquareButton width="131px" backgroundColor={'deepgreen'} onClick={handleSave} disabled={!canSave}>
+                <SquareButton width="131px" backgroundColor={'deepgreen'} onClick={handleSave}>
                     저장
                 </SquareButton>
                 <div>

--- a/src/pages/Career/FinalSummaryPage/FinalSummaryPage.jsx
+++ b/src/pages/Career/FinalSummaryPage/FinalSummaryPage.jsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import TextTemplate from '../../../components/common/TextTemplate/TextTemplate';
 import ProgressBar from '../../../components/common/ProgressBar/ProgressBar';
 import SquareButton from '../../../components/common/Button/SquareButton/SquareButton';
@@ -7,8 +8,9 @@ import useProgressBar from '../../../hooks/useProgressBar';
 import { TableCellHeader } from '../../../components/common/TextTemplate/styled/styled';
 
 const FinalSummaryPage = ({ setActiveScreen }) => {
+    const navigate = useNavigate();
     const { data, setData, handleSave } = useFinalSummary();
-    const { progression, prevSummaryProgress, nextSummaryProgress } = useProgressBar(5);
+    const { progression, prevSummaryProgress } = useProgressBar(5);
 
     const handlePrevClick = () => {
         prevSummaryProgress();
@@ -16,8 +18,7 @@ const FinalSummaryPage = ({ setActiveScreen }) => {
     };
 
     const handleNextClick = () => {
-        nextSummaryProgress();
-        setActiveScreen(5);
+        navigate('/career/success');
     };
 
     return (

--- a/src/pages/Career/FinalSummaryPage/FinalSummaryPage.jsx
+++ b/src/pages/Career/FinalSummaryPage/FinalSummaryPage.jsx
@@ -1,0 +1,58 @@
+import TextTemplate from '../../../components/common/TextTemplate/TextTemplate';
+import ProgressBar from '../../../components/common/ProgressBar/ProgressBar';
+import SquareButton from '../../../components/common/Button/SquareButton/SquareButton';
+import * as S from './styled/styled';
+import { useFinalSummary } from './useFinalSummary';
+import useProgressBar from '../../../hooks/useProgressBar';
+import { TableCellHeader } from '../../../components/common/TextTemplate/styled/styled';
+
+const FinalSummaryPage = ({ setActiveScreen }) => {
+    const { data, setData, canSave, handleSave } = useFinalSummary();
+    const { progression, prevSummaryProgress, nextSummaryProgress } = useProgressBar(5);
+
+    const handlePrevClick = () => {
+        prevSummaryProgress();
+        setActiveScreen(3);
+    };
+
+    const handleNextClick = () => {
+        nextSummaryProgress();
+        setActiveScreen(5);
+    };
+
+    return (
+        <S.PageWrapper>
+            <S.HeaderWrapper>
+                <S.TitleGroup>
+                    <S.Title>5. 최종 정리</S.Title>
+                    <S.Subtitle>※ 최대 2개까지 작성할 수 있어요.</S.Subtitle>
+                </S.TitleGroup>
+                <ProgressBar progression={progression} />
+            </S.HeaderWrapper>
+
+            <S.TemplateWrapper>
+                <TextTemplate
+                    data={data}
+                    onDataChange={(updatedData) => setData(updatedData)}
+                    TableCellHeader={TableCellHeader}
+                />
+            </S.TemplateWrapper>
+
+            <S.ButtonWrapper>
+                <SquareButton width="131px" backgroundColor={'deepgreen'} onClick={handleSave} disabled={!canSave}>
+                    저장
+                </SquareButton>
+                <div>
+                    <SquareButton width="131px" backgroundColor={'grey'} onClick={handlePrevClick}>
+                        이전
+                    </SquareButton>
+                    <SquareButton width="131px" backgroundColor={'lightgreen'} onClick={handleNextClick}>
+                        다음
+                    </SquareButton>
+                </div>
+            </S.ButtonWrapper>
+        </S.PageWrapper>
+    );
+};
+
+export default FinalSummaryPage;

--- a/src/pages/Career/FinalSummaryPage/styled/styled.js
+++ b/src/pages/Career/FinalSummaryPage/styled/styled.js
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+
+export const HeaderWrapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    max-width: 976px;
+    margin-top: 50px;
+`;
+
+export const TitleGroup = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+`;
+
+export const Title = styled.h1`
+    font-size: 26px;
+    font-weight: 700;
+    color: #000;
+    margin: 0;
+`;
+
+export const Subtitle = styled.p`
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 10px;
+    color: #c4c8ce;
+    text-align: center;
+    margin-left: 20px;
+`;
+
+export const PageWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    min-height: 100vh;
+    padding: 20px 0;
+`;
+
+export const ProgressBarWrapper = styled.div`
+    width: 100%;
+    max-width: 976px;
+`;
+
+export const TemplateWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    max-width: 976px;
+`;
+
+export const ButtonWrapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    max-width: 976px;
+    padding: 50px 0;
+
+    & > div {
+        display: flex;
+        gap: 15px;
+    }
+`;

--- a/src/pages/Career/FinalSummaryPage/useFinalSummary.js
+++ b/src/pages/Career/FinalSummaryPage/useFinalSummary.js
@@ -1,40 +1,19 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { textTemplateData } from '../../../data/textTemplateData';
 
 export const useFinalSummary = () => {
     const initialData = textTemplateData['summary']['frontend'];
     const [data, setData] = useState(initialData);
-    const [canSave, setCanSave] = useState(false);
-
-    const checkIfCanSave = () => {
-        const isValid = data.some((section) => {
-            return section.items.slice(0, 4).every((item) => {
-                if (item.type === 'date') {
-                    return item.startDate !== null && item.endDate !== null;
-                }
-                return item.content.trim().length > 0;
-            });
-        });
-        setCanSave(isValid);
-    };
-
-    useEffect(() => {
-        checkIfCanSave();
-    }, [data]);
 
     const handleSave = () => {
-        if (!canSave) {
-            alert('필수 항목을 모두 입력해주세요!');
-        } else {
-            alert('저장되었습니다.');
-            setData([...data]);
-        }
+        alert('저장되었습니다.');
+        setData([...data]);
     };
 
     return {
         data,
         setData,
-        canSave,
+        canSave: true,
         handleSave,
     };
 };

--- a/src/pages/Career/FinalSummaryPage/useFinalSummary.js
+++ b/src/pages/Career/FinalSummaryPage/useFinalSummary.js
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import { textTemplateData } from '../../../data/textTemplateData';
+
+export const useFinalSummary = () => {
+    const initialData = textTemplateData['summary']['frontend'];
+    const [data, setData] = useState(initialData);
+    const [canSave, setCanSave] = useState(false);
+
+    const checkIfCanSave = () => {
+        const isValid = data.some((section) => {
+            return section.items.slice(0, 4).every((item) => {
+                if (item.type === 'date') {
+                    return item.startDate !== null && item.endDate !== null;
+                }
+                return item.content.trim().length > 0;
+            });
+        });
+        setCanSave(isValid);
+    };
+
+    useEffect(() => {
+        checkIfCanSave();
+    }, [data]);
+
+    const handleSave = () => {
+        if (!canSave) {
+            alert('필수 항목을 모두 입력해주세요!');
+        } else {
+            alert('저장되었습니다.');
+            setData([...data]);
+        }
+    };
+
+    return {
+        data,
+        setData,
+        canSave,
+        handleSave,
+    };
+};

--- a/src/pages/Career/InternExperiencePage/InternExperiencePage.jsx
+++ b/src/pages/Career/InternExperiencePage/InternExperiencePage.jsx
@@ -17,7 +17,10 @@ const InternExperiencePage = ({ setActiveScreen }) => {
     return (
         <S.PageWrapper>
             <S.HeaderWrapper>
-                <S.Title>1. 인턴 경험</S.Title>
+                <S.TitleGroup>
+                    <S.Title>1. 인턴 경험</S.Title>
+                    <S.Subtitle>※ 최대 2개까지 작성할 수 있어요.</S.Subtitle>
+                </S.TitleGroup>
                 <ProgressBar progression={progression} />
             </S.HeaderWrapper>
 

--- a/src/pages/Career/InternExperiencePage/InternExperiencePage.jsx
+++ b/src/pages/Career/InternExperiencePage/InternExperiencePage.jsx
@@ -25,6 +25,7 @@ const InternExperiencePage = ({ setActiveScreen }) => {
                 <Template
                     jobType="frontend"
                     pageType="internExperience"
+                    data={data}
                     onDataChange={(updatedData) => setData(updatedData)}
                 />
             </S.TemplateWrapper>

--- a/src/pages/Career/InternExperiencePage/styled/styled.js
+++ b/src/pages/Career/InternExperiencePage/styled/styled.js
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 export const HeaderWrapper = styled.div`
     display: flex;
-    flex-direction: row;
     justify-content: space-between;
     align-items: center;
     width: 100%;
@@ -10,11 +9,26 @@ export const HeaderWrapper = styled.div`
     margin-top: 50px;
 `;
 
+export const TitleGroup = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+`;
+
 export const Title = styled.h1`
     font-size: 26px;
     font-weight: 700;
     color: #000;
     margin: 0;
+`;
+
+export const Subtitle = styled.p`
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 10px;
+    color: #c4c8ce;
+    text-align: center;
+    margin-left: 20px;
 `;
 
 export const PageWrapper = styled.div`

--- a/src/pages/Career/InternExperiencePage/useInternExperience.js
+++ b/src/pages/Career/InternExperiencePage/useInternExperience.js
@@ -27,6 +27,7 @@ export const useInternExperience = () => {
             alert('필수 항목을 모두 입력해주세요!');
         } else {
             alert('저장되었습니다.');
+            setData([...data]);
         }
     };
 

--- a/src/pages/Career/OtherExperiencePage/OtherExperiencePage.jsx
+++ b/src/pages/Career/OtherExperiencePage/OtherExperiencePage.jsx
@@ -1,0 +1,58 @@
+import Template from '../../../components/common/UserTemplate/Template';
+import ProgressBar from '../../../components/common/ProgressBar/ProgressBar';
+import SquareButton from '../../../components/common/Button/SquareButton/SquareButton';
+import * as S from './styled/styled';
+import { useOtherExperience } from './useOtherExperience';
+import useProgressBar from '../../../hooks/useProgressBar';
+
+const OtherExperiencePage = ({ setActiveScreen }) => {
+    const { data, setData, canSave, handleSave } = useOtherExperience();
+    const { progression, prevSummaryProgress, nextSummaryProgress } = useProgressBar(3);
+
+    const handlePrevClick = () => {
+        prevSummaryProgress();
+        setActiveScreen(1);
+    };
+
+    const handleNextClick = () => {
+        nextSummaryProgress();
+        setActiveScreen(3);
+    };
+
+    return (
+        <S.PageWrapper>
+            <S.HeaderWrapper>
+                <S.TitleGroup>
+                    <S.Title>3. 기타 경험</S.Title>
+                    <S.Subtitle>※ 최대 2개까지 작성할 수 있어요.</S.Subtitle>
+                </S.TitleGroup>
+                <ProgressBar progression={progression} />
+            </S.HeaderWrapper>
+
+            <S.TemplateWrapper>
+                <Template
+                    jobType="frontend"
+                    pageType="otherExperience"
+                    data={data}
+                    onDataChange={(updatedData) => setData(updatedData)}
+                />
+            </S.TemplateWrapper>
+
+            <S.ButtonWrapper>
+                <SquareButton width="131px" backgroundColor={'deepgreen'} onClick={handleSave} disabled={!canSave}>
+                    저장
+                </SquareButton>
+                <div>
+                    <SquareButton width="131px" backgroundColor={'grey'} onClick={handlePrevClick}>
+                        이전
+                    </SquareButton>
+                    <SquareButton width="131px" backgroundColor={'lightgreen'} onClick={handleNextClick}>
+                        다음
+                    </SquareButton>
+                </div>
+            </S.ButtonWrapper>
+        </S.PageWrapper>
+    );
+};
+
+export default OtherExperiencePage;

--- a/src/pages/Career/OtherExperiencePage/styled/styled.js
+++ b/src/pages/Career/OtherExperiencePage/styled/styled.js
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+
+export const HeaderWrapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    max-width: 976px;
+    margin-top: 50px;
+`;
+
+export const TitleGroup = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+`;
+
+export const Title = styled.h1`
+    font-size: 26px;
+    font-weight: 700;
+    color: #000;
+    margin: 0;
+`;
+
+export const Subtitle = styled.p`
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 10px;
+    color: #c4c8ce;
+    text-align: center;
+    margin-left: 20px;
+`;
+
+export const PageWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    min-height: 100vh;
+    padding: 20px 0;
+`;
+
+export const ProgressBarWrapper = styled.div`
+    width: 100%;
+    max-width: 976px;
+`;
+
+export const TemplateWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    max-width: 976px;
+`;
+
+export const ButtonWrapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    max-width: 976px;
+    padding: 50px 0;
+
+    & > div {
+        display: flex;
+        gap: 15px;
+    }
+`;

--- a/src/pages/Career/OtherExperiencePage/useOtherExperience.js
+++ b/src/pages/Career/OtherExperiencePage/useOtherExperience.js
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import { jobTemplateData } from '../../../data/jobTemplateData';
+
+export const useOtherExperience = () => {
+    const initialData = jobTemplateData['otherExperience']['frontend'];
+    const [data, setData] = useState(initialData);
+    const [canSave, setCanSave] = useState(false);
+
+    const checkIfCanSave = () => {
+        const isValid = data.some((section) => {
+            return section.items.slice(0, 4).every((item) => {
+                if (item.type === 'date') {
+                    return item.startDate !== null && item.endDate !== null;
+                }
+                return item.content.trim().length > 0;
+            });
+        });
+        setCanSave(isValid);
+    };
+
+    useEffect(() => {
+        checkIfCanSave();
+    }, [data]);
+
+    const handleSave = () => {
+        if (!canSave) {
+            alert('필수 항목을 모두 입력해주세요!');
+        } else {
+            alert('저장되었습니다.');
+            setData([...data]);
+        }
+    };
+
+    return {
+        data,
+        setData,
+        canSave,
+        handleSave,
+    };
+};

--- a/src/pages/Career/ProjectExperiencePage/ProjectExperiencePage.jsx
+++ b/src/pages/Career/ProjectExperiencePage/ProjectExperiencePage.jsx
@@ -38,12 +38,14 @@ const ProjectExperiencePage = ({ setActiveScreen }) => {
                 <SquareButton width="131px" backgroundColor={'deepgreen'} onClick={handleSave} disabled={!canSave}>
                     저장
                 </SquareButton>
-                <SquareButton width="131px" backgroundColor={'grey'} onClick={handlePrevClick}>
-                    이전
-                </SquareButton>
-                <SquareButton width="131px" backgroundColor={'lightgreen'} onClick={handleNextClick}>
-                    다음
-                </SquareButton>
+                <div>
+                    <SquareButton width="131px" backgroundColor={'grey'} onClick={handlePrevClick}>
+                        이전
+                    </SquareButton>
+                    <SquareButton width="131px" backgroundColor={'lightgreen'} onClick={handleNextClick}>
+                        다음
+                    </SquareButton>
+                </div>
             </S.ButtonWrapper>
         </S.PageWrapper>
     );

--- a/src/pages/Career/ProjectExperiencePage/ProjectExperiencePage.jsx
+++ b/src/pages/Career/ProjectExperiencePage/ProjectExperiencePage.jsx
@@ -1,0 +1,44 @@
+import Template from '../../../components/common/UserTemplate/Template';
+import ProgressBar from '../../../components/common/ProgressBar/ProgressBar';
+import SquareButton from '../../../components/common/Button/SquareButton/SquareButton';
+import * as S from './styled/styled';
+import { useProjectExperience } from './useProjectExperience';
+import useProgressBar from '../../../hooks/useProgressBar';
+
+const ProjectExperiencePage = ({ setActiveScreen }) => {
+    const { data, setData, canSave, handleSave } = useProjectExperience();
+    const { progression, prevSummaryProgress, nextSummaryProgress } = useProgressBar(1);
+
+    const handleNextClick = () => {
+        nextSummaryProgress();
+        setActiveScreen(1);
+    };
+
+    return (
+        <S.PageWrapper>
+            <S.HeaderWrapper>
+                <S.Title>2. 프로젝트 경험</S.Title>
+                <ProgressBar progression={progression} />
+            </S.HeaderWrapper>
+
+            <S.TemplateWrapper>
+                <Template
+                    jobType="frontend"
+                    pageType="projectExperience"
+                    onDataChange={(updatedData) => setData(updatedData)}
+                />
+            </S.TemplateWrapper>
+
+            <S.ButtonWrapper>
+                <SquareButton width="131px" backgroundColor={'deepgreen'} onClick={handleSave} disabled={!canSave}>
+                    저장
+                </SquareButton>
+                <SquareButton width="131px" backgroundColor={'lightgreen'} onClick={handleNextClick}>
+                    다음
+                </SquareButton>
+            </S.ButtonWrapper>
+        </S.PageWrapper>
+    );
+};
+
+export default ProjectExperiencePage;

--- a/src/pages/Career/ProjectExperiencePage/ProjectExperiencePage.jsx
+++ b/src/pages/Career/ProjectExperiencePage/ProjectExperiencePage.jsx
@@ -22,7 +22,10 @@ const ProjectExperiencePage = ({ setActiveScreen }) => {
     return (
         <S.PageWrapper>
             <S.HeaderWrapper>
-                <S.Title>2. 프로젝트 경험</S.Title>
+                <S.TitleGroup>
+                    <S.Title>2. 프로젝트 경험</S.Title>
+                    <S.Subtitle>※ 최대 2개까지 작성할 수 있어요.</S.Subtitle>
+                </S.TitleGroup>
                 <ProgressBar progression={progression} />
             </S.HeaderWrapper>
 

--- a/src/pages/Career/ProjectExperiencePage/ProjectExperiencePage.jsx
+++ b/src/pages/Career/ProjectExperiencePage/ProjectExperiencePage.jsx
@@ -30,6 +30,7 @@ const ProjectExperiencePage = ({ setActiveScreen }) => {
                 <Template
                     jobType="frontend"
                     pageType="projectExperience"
+                    data={data}
                     onDataChange={(updatedData) => setData(updatedData)}
                 />
             </S.TemplateWrapper>

--- a/src/pages/Career/ProjectExperiencePage/ProjectExperiencePage.jsx
+++ b/src/pages/Career/ProjectExperiencePage/ProjectExperiencePage.jsx
@@ -7,11 +7,16 @@ import useProgressBar from '../../../hooks/useProgressBar';
 
 const ProjectExperiencePage = ({ setActiveScreen }) => {
     const { data, setData, canSave, handleSave } = useProjectExperience();
-    const { progression, prevSummaryProgress, nextSummaryProgress } = useProgressBar(1);
+    const { progression, prevSummaryProgress, nextSummaryProgress } = useProgressBar(2);
+
+    const handlePrevClick = () => {
+        prevSummaryProgress();
+        setActiveScreen(0);
+    };
 
     const handleNextClick = () => {
         nextSummaryProgress();
-        setActiveScreen(1);
+        setActiveScreen(2);
     };
 
     return (
@@ -32,6 +37,9 @@ const ProjectExperiencePage = ({ setActiveScreen }) => {
             <S.ButtonWrapper>
                 <SquareButton width="131px" backgroundColor={'deepgreen'} onClick={handleSave} disabled={!canSave}>
                     저장
+                </SquareButton>
+                <SquareButton width="131px" backgroundColor={'grey'} onClick={handlePrevClick}>
+                    이전
                 </SquareButton>
                 <SquareButton width="131px" backgroundColor={'lightgreen'} onClick={handleNextClick}>
                     다음

--- a/src/pages/Career/ProjectExperiencePage/styled/styled.js
+++ b/src/pages/Career/ProjectExperiencePage/styled/styled.js
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+
+export const HeaderWrapper = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    max-width: 976px;
+    margin-top: 50px;
+`;
+
+export const Title = styled.h1`
+    font-size: 26px;
+    font-weight: 700;
+    color: #000;
+    margin: 0;
+`;
+
+export const PageWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    min-height: 100vh;
+    padding: 20px 0;
+`;
+
+export const ProgressBarWrapper = styled.div`
+    width: 100%;
+    max-width: 976px;
+`;
+
+export const TemplateWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    max-width: 976px;
+`;
+
+export const ButtonWrapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    max-width: 976px;
+    padding: 50px 0;
+`;

--- a/src/pages/Career/ProjectExperiencePage/styled/styled.js
+++ b/src/pages/Career/ProjectExperiencePage/styled/styled.js
@@ -48,4 +48,9 @@ export const ButtonWrapper = styled.div`
     width: 100%;
     max-width: 976px;
     padding: 50px 0;
+
+    & > div {
+        display: flex;
+        gap: 15px;
+    }
 `;

--- a/src/pages/Career/ProjectExperiencePage/styled/styled.js
+++ b/src/pages/Career/ProjectExperiencePage/styled/styled.js
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 export const HeaderWrapper = styled.div`
     display: flex;
-    flex-direction: row;
     justify-content: space-between;
     align-items: center;
     width: 100%;
@@ -10,11 +9,26 @@ export const HeaderWrapper = styled.div`
     margin-top: 50px;
 `;
 
+export const TitleGroup = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+`;
+
 export const Title = styled.h1`
     font-size: 26px;
     font-weight: 700;
     color: #000;
     margin: 0;
+`;
+
+export const Subtitle = styled.p`
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 10px;
+    color: #c4c8ce;
+    text-align: center;
+    margin-left: 20px;
 `;
 
 export const PageWrapper = styled.div`

--- a/src/pages/Career/ProjectExperiencePage/useProjectExperience.js
+++ b/src/pages/Career/ProjectExperiencePage/useProjectExperience.js
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+import { jobTemplateData } from '../../../data/jobTemplateData';
+
+export const useProjectExperience = () => {
+    const initialData = jobTemplateData['projectExperience']['frontend'];
+    const [data, setData] = useState(initialData);
+    const [canSave, setCanSave] = useState(false);
+
+    const checkIfCanSave = () => {
+        const isValid = data.some((section) => {
+            return section.items.slice(0, 4).every((item) => {
+                if (item.type === 'date') {
+                    return item.startDate !== null && item.endDate !== null;
+                }
+                return item.content.trim().length > 0;
+            });
+        });
+        setCanSave(isValid);
+    };
+
+    useEffect(() => {
+        checkIfCanSave();
+    }, [data]);
+
+    const handleSave = () => {
+        if (!canSave) {
+            alert('필수 항목을 모두 입력해주세요!');
+        } else {
+            alert('저장되었습니다.');
+        }
+    };
+
+    return {
+        data,
+        setData,
+        canSave,
+        handleSave,
+    };
+};

--- a/src/pages/Career/ProjectExperiencePage/useProjectExperience.js
+++ b/src/pages/Career/ProjectExperiencePage/useProjectExperience.js
@@ -27,6 +27,7 @@ export const useProjectExperience = () => {
             alert('필수 항목을 모두 입력해주세요!');
         } else {
             alert('저장되었습니다.');
+            setData([...data]);
         }
     };
 

--- a/src/pages/Career/SkillsPage/SkillsPage.jsx
+++ b/src/pages/Career/SkillsPage/SkillsPage.jsx
@@ -30,7 +30,11 @@ const SkillsPage = ({ setActiveScreen }) => {
             </S.HeaderWrapper>
 
             <S.TemplateWrapper>
-                <TextTemplate data={data} onDataChange={(updatedData) => setData(updatedData)} />
+                <TextTemplate
+                    data={data}
+                    onDataChange={(updatedData) => setData(updatedData)}
+                    TableCellHeader={S.SkillsPageTableCellHeader}
+                />
             </S.TemplateWrapper>
 
             <S.ButtonWrapper>

--- a/src/pages/Career/SkillsPage/SkillsPage.jsx
+++ b/src/pages/Career/SkillsPage/SkillsPage.jsx
@@ -1,0 +1,53 @@
+import TextTemplate from '../../../components/common/TextTemplate/TextTemplate';
+import ProgressBar from '../../../components/common/ProgressBar/ProgressBar';
+import SquareButton from '../../../components/common/Button/SquareButton/SquareButton';
+import * as S from './styled/styled';
+import { useSkills } from './useSkills';
+import useProgressBar from '../../../hooks/useProgressBar';
+
+const SkillsPage = ({ setActiveScreen }) => {
+    const { data, setData, canSave, handleSave } = useSkills();
+    const { progression, prevSummaryProgress, nextSummaryProgress } = useProgressBar(4);
+
+    const handlePrevClick = () => {
+        prevSummaryProgress();
+        setActiveScreen(2);
+    };
+
+    const handleNextClick = () => {
+        nextSummaryProgress();
+        setActiveScreen(4);
+    };
+
+    return (
+        <S.PageWrapper>
+            <S.HeaderWrapper>
+                <S.TitleGroup>
+                    <S.Title>4. 보유 기술 및 업무 성향</S.Title>
+                    <S.Subtitle>※ 최대 2개까지 작성할 수 있어요.</S.Subtitle>
+                </S.TitleGroup>
+                <ProgressBar progression={progression} />
+            </S.HeaderWrapper>
+
+            <S.TemplateWrapper>
+                <TextTemplate data={data} onDataChange={(updatedData) => setData(updatedData)} />
+            </S.TemplateWrapper>
+
+            <S.ButtonWrapper>
+                <SquareButton width="131px" backgroundColor={'deepgreen'} onClick={handleSave} disabled={!canSave}>
+                    저장
+                </SquareButton>
+                <div>
+                    <SquareButton width="131px" backgroundColor={'grey'} onClick={handlePrevClick}>
+                        이전
+                    </SquareButton>
+                    <SquareButton width="131px" backgroundColor={'lightgreen'} onClick={handleNextClick}>
+                        다음
+                    </SquareButton>
+                </div>
+            </S.ButtonWrapper>
+        </S.PageWrapper>
+    );
+};
+
+export default SkillsPage;

--- a/src/pages/Career/SkillsPage/styled/styled.js
+++ b/src/pages/Career/SkillsPage/styled/styled.js
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+
+export const HeaderWrapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    max-width: 976px;
+    margin-top: 50px;
+`;
+
+export const TitleGroup = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+`;
+
+export const Title = styled.h1`
+    font-size: 26px;
+    font-weight: 700;
+    color: #000;
+    margin: 0;
+`;
+
+export const Subtitle = styled.p`
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 10px;
+    color: #c4c8ce;
+    text-align: center;
+    margin-left: 20px;
+`;
+
+export const PageWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    min-height: 100vh;
+    padding: 20px 0;
+`;
+
+export const ProgressBarWrapper = styled.div`
+    width: 100%;
+    max-width: 976px;
+`;
+
+export const TemplateWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    max-width: 976px;
+`;
+
+export const ButtonWrapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    max-width: 976px;
+    padding: 50px 0;
+
+    & > div {
+        display: flex;
+        gap: 15px;
+    }
+`;

--- a/src/pages/Career/SkillsPage/styled/styled.js
+++ b/src/pages/Career/SkillsPage/styled/styled.js
@@ -1,4 +1,11 @@
 import styled from 'styled-components';
+import { TableCellHeader as OriginalTableCellHeader } from '../../../../components/common/TextTemplate/styled/styled';
+
+export const SkillsPageTableCellHeader = styled(OriginalTableCellHeader)`
+    width: 17%;
+    align-items: center;
+    justify-content: center;
+`;
 
 export const HeaderWrapper = styled.div`
     display: flex;

--- a/src/pages/Career/SkillsPage/useSkills.js
+++ b/src/pages/Career/SkillsPage/useSkills.js
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import { textTemplateData } from '../../../data/textTemplateData';
+
+export const useSkills = () => {
+    const initialData = textTemplateData['skills']['frontend'];
+    const [data, setData] = useState(initialData);
+    const [canSave, setCanSave] = useState(false);
+
+    const checkIfCanSave = () => {
+        const isValid = data.some((section) => {
+            return section.items.slice(0, 4).every((item) => {
+                if (item.type === 'date') {
+                    return item.startDate !== null && item.endDate !== null;
+                }
+                return item.content.trim().length > 0;
+            });
+        });
+        setCanSave(isValid);
+    };
+
+    useEffect(() => {
+        checkIfCanSave();
+    }, [data]);
+
+    const handleSave = () => {
+        if (!canSave) {
+            alert('필수 항목을 모두 입력해주세요!');
+        } else {
+            alert('저장되었습니다.');
+            setData([...data]);
+        }
+    };
+
+    return {
+        data,
+        setData,
+        canSave,
+        handleSave,
+    };
+};

--- a/src/pages/Career/SkillsPage/useSkills.js
+++ b/src/pages/Career/SkillsPage/useSkills.js
@@ -24,7 +24,7 @@ export const useSkills = () => {
 
     const handleSave = () => {
         if (!canSave) {
-            alert('필수 항목을 모두 입력해주세요!');
+            alert('항목을 모두 입력해주세요!');
         } else {
             alert('저장되었습니다.');
             setData([...data]);


### PR DESCRIPTION
## #️⃣ 관련 이슈
> #52 

## 📝 구현한 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요! (이미지 첨부 가능)
- 템플릿 작성하기 페이지 전체 개발 (인턴 경험, 프로젝트 경험, 기타 경험, 보유 기술, 최종 정리) 
- 메인화면~저장완료 페이지까지 라우팅 연결 완료
- 최종 정리 페이지만 입력 여부 상관없이 저장 가능, 나머지 페이지들은 필수 항목 입력 시에만 저장 가능
- 각 섹션별로 전체 내용 삭제 기능 추가
![ViteReact-Chrome2025-01-2120-00-18-Trim-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/91de587c-c806-4c32-90d5-0732d326b1bb)


---

## 🚨 체크리스트
- [x] 코드 컨벤션 준수 여부 확인
- [x] PR 제목을 컨벤션에 맞게 작성 확인
- [x] develop 및 feature 브랜치 최신 상태 반영하고 있는지 확인
- [x] reviewers 파트장 포함 2명 설정했는지 확인
- [x] 현재 브랜치 및 merge 하려는 브랜치 확인

## 💬 리뷰 요청 사항(선택)
> 템플릿 작성하기 각 페이지마다 hooks와 style이 조금씩 달라 폴더별로 분리했습니다. '저장' 버튼 입력 후 입력 필드 내용 유지는 API 연동 후 작업할 예정입니다!
