### PR TITLE
[Feat] useFetchProfile에 enable=isLogin 설정

### DIFF
--- a/src/apis/Profile/useProfileApi.js
+++ b/src/apis/Profile/useProfileApi.js
@@ -34,12 +34,13 @@ export const useEditProfile = (profile) => {
     });
 };
 
-export const useFetchProfile = () => {
+export const useFetchProfile = (isLogin) => {
     const { data, isLoading, isError, error } = useQuery({
         queryKey: ['profile'],
         queryFn: getProfile,
         retry: 0,
         refetchOnWindowFocus: false,
+        enabled: isLogin,
     });
     return { data, isLoading, isError, error };
 };

--- a/src/pages/Main/MainPage/MainPage.jsx
+++ b/src/pages/Main/MainPage/MainPage.jsx
@@ -42,12 +42,19 @@ const MainPage = () => {
     const location = useLocation();
     const queryParams = new URLSearchParams(location.search);
     const userName = queryParams.get('name');
+    const { data, error } = useFetchProfile(isLogin);
 
     useEffect(() => {
         if (userName) {
             login({ name: userName });
         }
     }, [userName, login]);
+
+    useEffect(() => {
+        if (isLogin && data) {
+            fetchUser(data);
+        }
+    }, [isLogin, data]);
 
     const isMobileScreen = useIsMobileScreen(430);
     const buttonWidth = isMobileScreen ? '240px' : '400px';


### PR DESCRIPTION
## #️⃣ 관련 이슈
> ex) #이슈번호, #이슈번호

## 📝 구현한 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요! (이미지 첨부 가능)
>
- 로그인 상태일 경우에만 GET /member 요청하도록 useFetchProfile 수정
- MainPage에 useFetchProfile 추가

- 로그아웃 상태일 때 GET 요청 안 가는 거 테스트 완료
---

## 🚨 체크리스트
- [x] 코드 컨벤션 준수 여부 확인
- [x] PR 제목을 컨벤션에 맞게 작성 확인
- [x] develop 및 feature 브랜치 최신 상태 반영하고 있는지 확인
- [x] reviewers 파트장 포함 2명 설정했는지 확인
- [x] 현재 브랜치 및 merge 하려는 브랜치 확인

## 💬 리뷰 요청 사항(선택)
> 특정 코드 영역에 대한 피드백 요청
- 로컬에서 로그인 상태로 변경하고 싶은 경우
  - localhost:5173/?name=이름 url 입력 후 .env에 최신 토큰 넣어놓기
- 로컬에서 로그아웃 불가능: 로컬에서는 백엔드와 토큰 통신이 불가
  -  로컬에서 로그아웃 상태로 변경하고 싶은 경우,
   네비바의 handleLogout의 mutate를 주석 처리 한 후 useAuthStore의 logout을 넣어주세요
 