### PR TITLE
[Style] Card 컴포넌트 타이틀 잘림 수정[모바일] 및 이미지 object-fit 설정

### DIFF
--- a/src/components/common/Card/styled/styled.js
+++ b/src/components/common/Card/styled/styled.js
@@ -38,6 +38,7 @@ export const Thumbnail = styled.img`
     width: 260px;
     height: ${({ $type }) => ($type ? '150px' : '130px')};
     border-radius: 20px;
+    object-fit: cover;
 
     @media (max-width: 431px) {
         width: 254px;
@@ -77,6 +78,10 @@ export const DeadlineWrapper = styled.div`
     flex-direction: row;
     justify-content: ${({ $type }) => ($type ? 'flex-end' : 'space-between')};
     align-items: center;
+
+    @media (max-width: 431px) {
+        height: 40px;
+    }
 `;
 
 export const Deadline = styled.div`


### PR DESCRIPTION
## #️⃣ 관련 이슈
> #121 

## 📝 구현한 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요! (이미지 첨부 가능)
> -  Card 컴포넌트 타이틀 잘림 수정[모바일] 및 이미지 object-fit 설정
![image](https://github.com/user-attachments/assets/d87eed58-5596-4c6c-83e9-0a234d2d9668)

---

## 🚨 체크리스트
- [x] 코드 컨벤션 준수 여부 확인
- [x] PR 제목을 컨벤션에 맞게 작성 확인
- [x] develop 및 feature 브랜치 최신 상태 반영하고 있는지 확인
- [x] reviewers 파트장 포함 2명 설정했는지 확인
- [x] 현재 브랜치 및 merge 하려는 브랜치 확인

## 💬 리뷰 요청 사항(선택)
> 특정 코드 영역에 대한 피드백 요청
